### PR TITLE
removed pass config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -6,7 +6,6 @@
       "title": "Library",
       "environments": [ "edit" ],
       "isPalette": true,
-      "passConfig": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
       "url": "https://main--milo--adobecom.hlx.page/tools/library",
       "includePaths": [ "**.docx**" ]


### PR DESCRIPTION

Gets Library to load. To test locally: 
- Open sidekick config
- Select advanced on left sidebar
- Edit bacom blog project
- Select "Test configuration locally" 

<img width="274" alt="image" src="https://user-images.githubusercontent.com/7562106/227326067-1474735c-1de2-4795-a2b8-b8414af81a0f.png">

After removing the line in this PR, library should load. 
