### PR TITLE
[MWPW-135321] Adding the content root

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -108,6 +108,7 @@ const CONFIG = {
   },
   // geoRouting: 'on',
   productionDomain: 'business.adobe.com',
+  contentRoot: '/blog',
 };
 
 // Load LCP image immediately


### PR DESCRIPTION
* Adds the contentRoot to config

Note: To verify you need to look in the network tab and make sure that the requests for the gnav and footer have `/blog` in the request URI.

Resolves: [MWPW-135321](https://jira.corp.adobe.com/browse/MWPW-135321)

**Test URLs:**
- Before: https://main--bacom-blog--adobecom.hlx.page/drafts/bulk-update/MWPW-135074-CSS-Styles/10-best-practices-for-using-links-in-emails?martech=off
- After: https://content-root--bacom-blog--adobecom.hlx.page/drafts/bulk-update/MWPW-135074-CSS-Styles/10-best-practices-for-using-links-in-emails?martech=off
