### PR TITLE
Adding prod domains to config

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -108,6 +108,7 @@ const CONFIG = {
   },
   // geoRouting: 'on',
   productionDomain: 'business.adobe.com',
+  prodDomains: ['business.adobe.com'],
   contentRoot: '/blog',
   taxonomyRoot: '/tags',
 };


### PR DESCRIPTION
* Adds `prodDomains` to config. localizeLink utilizes it in its checks to see if it needs to localize or not. Currently some executions of the script return undefined which may interfere with the function. 

N/A

**Test URLs:**
N/A
