### PR TITLE
MWPW-142563: Add Eager Loading to LPC Image for Blog

### DIFF
--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -158,7 +158,7 @@ const prelooadLCP = (img) => {
 
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'bacom-blog', tags: 'default' });
-  prelooadLCP(document.querySelector('img'));
   await buildAutoBlocks();
   await loadArea();
+  prelooadLCP(document.querySelector('img'));
 }());

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -147,7 +147,7 @@ const prelooadLCP = (img) => {
   link.setAttribute('rel', 'preload');
   link.setAttribute('fetchpriority', 'high');
   link.setAttribute('as', 'image');
-  link.setAttribute('href', `${imgUrl.pathname}`);
+  link.setAttribute('href', `${imgUrl.pathname}${imgUrl.search}`);
   link.setAttribute('type', 'image/webp');
   console.log(link, img.src, imgUrl.pathname);
   document.head.appendChild(link);

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -141,6 +141,18 @@ const miloLibs = setLibs(LIBS);
   });
 }());
 
+const prelooadLCP = (img) => {
+  const imgUrl = new URL(img);
+  const link = document.createElement('link');
+  link.setAttribute('rel', 'preload');
+  link.setAttribute('fetchpriority', 'high');
+  link.setAttribute('as', 'image');
+  link.setAttribute('href', `${imgUrl.path}`);
+  link.setAttrubte('type', 'image/webp');
+  console.log(link);
+  document.head.appendChild(link);
+};
+
 (async function loadPage() {
   const { loadArea, setConfig, loadLana } = await import(`${miloLibs}/utils/utils.js`);
 
@@ -148,4 +160,5 @@ const miloLibs = setLibs(LIBS);
   loadLana({ clientId: 'bacom-blog', tags: 'default' });
   await buildAutoBlocks();
   await loadArea();
+  prelooadLCP(document.querySelector('img'));
 }());

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -141,18 +141,6 @@ const miloLibs = setLibs(LIBS);
   });
 }());
 
-const prelooadLCP = (img) => {
-  const imgUrl = new URL(img.src);
-  const link = document.createElement('link');
-  link.setAttribute('rel', 'preload');
-  link.setAttribute('fetchpriority', 'high');
-  link.setAttribute('as', 'image');
-  link.setAttribute('href', `${imgUrl.pathname}${imgUrl.search}`);
-  link.setAttribute('type', 'image/webp');
-  console.log(link, img.src, imgUrl.pathname);
-  document.head.appendChild(link);
-};
-
 (async function loadPage() {
   const { loadArea, setConfig, loadLana } = await import(`${miloLibs}/utils/utils.js`);
 
@@ -160,5 +148,4 @@ const prelooadLCP = (img) => {
   loadLana({ clientId: 'bacom-blog', tags: 'default' });
   await buildAutoBlocks();
   await loadArea();
-  prelooadLCP(document.querySelector('img'));
 }());

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -118,7 +118,8 @@ const CONFIG = {
 // Load LCP image immediately
 (function loadLCPImage() {
   const lcpImg = document.querySelector('img');
-  lcpImg?.removeAttribute('loading');
+  lcpImg?.setAttribute('loading', 'eager');
+  lcpImg?.setAttribute('fetchpriority', 'high');
 }());
 
 /*

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -142,14 +142,14 @@ const miloLibs = setLibs(LIBS);
 }());
 
 const prelooadLCP = (img) => {
-  const imgUrl = new URL(img);
+  const imgUrl = new URL(img.src);
   const link = document.createElement('link');
   link.setAttribute('rel', 'preload');
   link.setAttribute('fetchpriority', 'high');
   link.setAttribute('as', 'image');
-  link.setAttribute('href', `${imgUrl.path}`);
-  link.setAttrubte('type', 'image/webp');
-  console.log(link);
+  link.setAttribute('href', `${imgUrl.pathname}`);
+  link.setAttribute('type', 'image/webp');
+  console.log(link, img.src, imgUrl.pathname);
   document.head.appendChild(link);
 };
 

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -158,7 +158,7 @@ const prelooadLCP = (img) => {
 
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'bacom-blog', tags: 'default' });
+  prelooadLCP(document.querySelector('img'));
   await buildAutoBlocks();
   await loadArea();
-  prelooadLCP(document.querySelector('img'));
 }());


### PR DESCRIPTION
* Adds `loading: eager` and `fetchpriority: high` to blog. 

Context: There was never a large difference in the PSI scores when testing. However, I am hoping that this will get us more in line with Brand Blog and we will see CrUX scores benefit from the change. 

Resolves: [MWPW-142563](https://jira.corp.adobe.com/browse/MWPW-142563)

**Test URLs:**
- Before: https://main--bacom-blog--adobecom.hlx.page/blog/basics/what-is-a-cms-and-how-does-it-work?martech=off
- After: https://eager-poc--bacom-blog--adobecom.hlx.page/blog/basics/what-is-a-cms-and-how-does-it-work?martech=off
