### PR TITLE
MWPW-144683 Article Header Unit Test

### DIFF
--- a/test/scripts/mocks/blocks/article-feed/article-helpers.js
+++ b/test/scripts/mocks/blocks/article-feed/article-helpers.js
@@ -1,0 +1,11 @@
+export function loadTaxonomy() {
+
+}
+
+export function getLinkForTopic() {
+  return '#';
+}
+
+export function getTaxonomyModule() {
+  return true;
+}

--- a/test/scripts/mocks/body.html
+++ b/test/scripts/mocks/body.html
@@ -1,6 +1,9 @@
 <main>
   <div>
     <h1 id="connecting-external-data-sources-to-adobe-experience-manager-guides-is-now-a-breeze">Connecting external data sources to Adobe Experience Manager Guides is now a breeze</h1>
+    <picture>
+      <img src="">
+    </picture>
     <p><em>Rohit Bansal is a principal product marketing manager at Adobe, leading global go-to-market strategy for Adobe Experience Manager Guides. With over 14 years of experience, Rohit has led marketing for product and services firms in the B2B domain — and managed key functions like product marketing, digital marketing, thought leadership, demand generation, and partner relations. A passionate data-driven marketer, he is also a big advocate of the customer experience.</em></p>
   </div>
 </main>

--- a/test/scripts/mocks/head.html
+++ b/test/scripts/mocks/head.html
@@ -1,0 +1,4 @@
+<meta name="publication-date" content="08-10-2023">
+<meta property="article:tag" content="Customer Intelligence">
+<meta property="article:tag" content="Customer Success">
+<meta name="category" content="The Latest">

--- a/test/scripts/mocks/utils/utils.js
+++ b/test/scripts/mocks/utils/utils.js
@@ -1,0 +1,8 @@
+export function getMetadata(name, doc = document) {
+  const attr = name && name.includes(':') ? 'property' : 'name';
+  const meta = doc.head.querySelector(`meta[${attr}="${name}"]`);
+  return meta && meta.content;
+}
+export function getConfig() {
+  return { locale: '' };
+}

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -46,13 +46,14 @@ describe('Libs', () => {
   });
 });
 
-const metadata = await readFile({ path: './mocks/tagsHead.html' });
+const metadata = await readFile({ path: './mocks/head.html' });
 
 window.lana = { log: () => {} };
 
 describe('Auto Blocks', () => {
   before(() => {
-    setLibs('/libs');
+    setLibs('/test/scripts/mocks', { hostname: 'none', search: '' });
+    document.head.innerHTML = metadata;
   });
 
   beforeEach(() => {
@@ -64,30 +65,32 @@ describe('Auto Blocks', () => {
   });
 
   it('catches errors', async () => {
-    document.head.innerHTML = metadata;
     document.body.innerHTML = '';
     await buildAutoBlocks();
     expect(window.lana.log.called).to.be.true;
   });
 
   it('builds the tags block', async () => {
-    document.head.innerHTML = metadata;
-    document.body.innerHTML = await readFile({ path: './mocks/tagsBody.html' });
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
     await buildAutoBlocks();
     expect(document.querySelector('.tags')).to.exist;
   });
 
   it('inserts the tags block before recommended articles if present', async () => {
-    document.head.innerHTML = metadata;
     document.body.innerHTML = await readFile({ path: './mocks/tagsWithRecBody.html' });
     await buildAutoBlocks();
     expect(document.querySelector('.tags + .recommended-articles')).to.exist;
   });
 
   it('inserts the tags block in section before recommended articles if present', async () => {
-    document.head.innerHTML = metadata;
     document.body.innerHTML = await readFile({ path: './mocks/tagsWithRecSectionBody.html' });
     await buildAutoBlocks();
     expect(document.querySelector('.before-rec .tags')).to.exist;
+  });
+
+  it('builds the article header block', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+    await buildAutoBlocks();
+    expect(document.querySelector('.article-header')).to.exist;
   });
 });


### PR DESCRIPTION
* Add unit test for the article header and add mocks
* Functionality for original PR (https://github.com/adobecom/bacom-blog/pull/37) was no longer needed but wanted to keep the unit tests

Related to: [MWPW-144683](https://jira.corp.adobe.com/browse/MWPW-144683)

**Test URLs:**
N/A
