### PR TITLE
MWPW-159614 Add dynamicNav key to config

### DIFF
--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -125,6 +125,7 @@ const CONFIG = {
   codeRoot: '/blog',
   taxonomyRoot: '/tags',
   links: 'on',
+  dynamicNavKey: 'bacom',
   stageDomainsMap: { 'business.stage.adobe.com': { 'business.adobe.com': 'origin' } },
 };
 


### PR DESCRIPTION
* Adds the dynamicNav key with value 'bacom' to blog. We want bacom pages to send the nav to blog, so the key should be the same. 

Resolves: [MWPW-159614](https://jira.corp.adobe.com/browse/MWPW-159614)

**Test URLs:**
- Before: https://main--bacom-blog--adobecom.hlx.page/?martech=off
- After: https://add-dynamic-nav-key--bacom-blog--adobecom.hlx.page/?martech=off
