### PR TITLE
MWPW-163083 Remove extra spacing above article header

### DIFF
--- a/blog/styles/styles.css
+++ b/blog/styles/styles.css
@@ -128,7 +128,17 @@ main p picture img {
 
 .recommended-articles-small-content-wrapper .article-card .article-card-body h3 {
   margin-bottom: 0;
-}  
+}
+
+main .article-header {
+  margin: 0;
+  padding-top: var(--spacing-xxl);
+}
+
+main .article-header .article-category div,
+main .article-header .article-category p {
+  margin: 0;
+}
 
 @media screen and (min-width: 600px) {
   body main {


### PR DESCRIPTION
* Aligns spacing above article header with figma designs

Resolves: [MWPW-163083](https://jira.corp.adobe.com/browse/MWPW-163083)

**Test URLs:**
With global navigation:
- Before: https://main--bacom-blog--adobecom.hlx.live/blog/the-latest/lenovo-talks-adobe-genstudio-for-performance-marketing
- After: https://article-spacing--bacom-blog--meganthecoder.hlx.live/blog/the-latest/lenovo-talks-adobe-genstudio-for-performance-marketing?martech=off

With old gnav (space slightly increases to align with figma):
- Before: https://main--bacom-blog--adobecom.hlx.live/fr/blog/actualites/entretien-avec-luc-dammann-le-nouveau-president-emea-d-adobe
- After: https://article-spacing--bacom-blog--meganthecoder.hlx.live/fr/blog/actualites/entretien-avec-luc-dammann-le-nouveau-president-emea-d-adobe?martech=off