### PR TITLE
Update Kodiak config to exclude package-lock.json

### DIFF
--- a/.kodiak/config.yaml
+++ b/.kodiak/config.yaml
@@ -32,3 +32,8 @@ notifications:
         components: # Please do not change this.
           - name: "DevOps Security"
           
+rules:
+  - match:
+      - path: "package-lock.json"
+    visibility:
+      - NONE


### PR DESCRIPTION

* Adds a `rule` stanza to the config that should exclude kodiak from flagging anything found in package-lock.json - mainly to stop Kodiak from making tickets for Peer Dependencies over which we have little to no control. 

**Test URLs:**
- Before: https://main--bacom-blog--adobecom.hlx.live/?martech=off
- After: https://update-kodiak-findings--bacom-blog--adobecom.hlx.live/?martech=off
