### PR TITLE
MWPW-183330 Block SBOM-grype from creating tickets

### DIFF
--- a/.kodiak/config.yaml
+++ b/.kodiak/config.yaml
@@ -15,6 +15,9 @@ notifications:
       filters:
         include:
           risk_rating: R3 # Please do not change this unless instructed to do so.
+        exclude:
+          tool_type:
+            - "grype" # Exclude SBOM tickets which duplicate findings already created by snyk
       fields:
         assignee:
           name: slavin


### PR DESCRIPTION
Blocks grype from creating duplicate CVE tickets

Resolves: [MWPW-183330](https://jira.corp.adobe.com/browse/MWPW-183330)

**Test URLs:**
- Before: https://main--bacom-blog--adobecom.hlx.page/?martech=off
- After: https://thedoc31-patch-1--bacom-blog--adobecom.hlx.page/?martech=off
